### PR TITLE
Adding support to metric whitelist selection, avoiding costs explosion on librato

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.tilde</groupId>
   <artifactId>kafka-librato-metrics-reporter</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
We are using the following property:

librato.kafka.metrics.whitelist=^AllTopicsMessagesInPerSec,^._MessagesInPerSec,^AllTopicsBytesInPerSec,^AllTopicsBytesOutPerSec,^Produce-RequestsPerSec,^Fetch-Consumer-RequestsPerSec,^FetchFollowerRequestsPerSec,^._-Size,^UnderReplicatedPartitions,^ActiveControllerCount,^PartitionCount,^LeaderCount,^LeaderElectionRateAndTimeMs,^UncleanLeaderElectionsPerSec,^IsrShrinksPerSec,^IsrExpandsPerSec,^Replica-MaxLag,^Produce-TotalTimeMs,^Fetch-Follower-TotalTimeMs,^Produce-RequestQueueTimeMs,^Fetch-Follower-RequestsPerSec,^Produce-LocalTimeMs,^Fetch-Follower-LocalTimeMs,^Fetch-Follower-RemoteTimeMs,^Produce-ResponseSendTimeMs,^Fetch-Follower-ResponseSendTimeMs

We expect to reduce our librato expenses with kafka in 70%
